### PR TITLE
Output handling of "doing" description logs

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -247,7 +247,7 @@ async fn prepare_directory(path: impl AsRef<Path>) -> Result<(), InfrastructureE
 }
 
 async fn run_rule(context: &Context, rule: &Rule) -> Result<(), InfrastructureError> {
-    // Acquire a semaphore first to guanrantee a lock orderi between a job semaphore and console.
+    // Acquire a job semaphore first to guanrantee a lock orderi between a job semaphore and console.
     let permit = context.job_semaphore().acquire().await?;
 
     let (output, mut console) = try_join!(

--- a/src/run.rs
+++ b/src/run.rs
@@ -247,7 +247,7 @@ async fn prepare_directory(path: impl AsRef<Path>) -> Result<(), InfrastructureE
 }
 
 async fn run_rule(context: &Context, rule: &Rule) -> Result<(), InfrastructureError> {
-    // Acquire a job semaphore first to guanrantee a lock orderi between a job semaphore and console.
+    // Acquire a job semaphore first to guanrantee a lock order between a job semaphore and console.
     let permit = context.job_semaphore().acquire().await?;
 
     let (output, mut console) = try_join!(

--- a/src/run.rs
+++ b/src/run.rs
@@ -247,7 +247,7 @@ async fn prepare_directory(path: impl AsRef<Path>) -> Result<(), InfrastructureE
 }
 
 async fn run_rule(context: &Context, rule: &Rule) -> Result<(), InfrastructureError> {
-    // Acquire a job semaphore first to guanrantee a lock order between a job semaphore and console.
+    // Acquire a job semaphore first to guarantee a lock order between a job semaphore and console.
     let permit = context.job_semaphore().acquire().await?;
 
     let (output, mut console) = try_join!(


### PR DESCRIPTION
Output handling similar to `cargo build`'s, where you can say "doing" (e.g. "Compiling ..." or "Linking ...") in rule descriptions.